### PR TITLE
Migrate RecyclerRefreshLayout and sample app to AndroidX

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,9 +21,12 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile 'com.android.support:design:25.3.1'
-    compile 'com.android.support:recyclerview-v7:25.3.1'
-    compile 'com.android.support:cardview-v7:25.3.1'
+    compile 'androidx.appcompat:appcompat:1.0.0'
+    compile 'androidx.cardview:cardview:1.0.0'
+    compile 'androidx.fragment:fragment:1.0.0'
+    compile 'androidx.coordinatorlayout:coordinatorlayout:1.0.0'
+    compile 'androidx.recyclerview:recyclerview:1.0.0'
+    compile 'androidx.viewpager:viewpager:1.0.0'
+    compile 'com.google.android.material:material:1.0.0'
     compile project(':recyclerrefreshlayout')
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.dinuscxj.recyclerrefreshlayout"
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/app/src/main/java/com/dinuscxj/example/adapter/BaseRecyclerListAdapter.java
+++ b/app/src/main/java/com/dinuscxj/example/adapter/BaseRecyclerListAdapter.java
@@ -1,8 +1,8 @@
 package com.dinuscxj.example.adapter;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.UiThread;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.UiThread;
+import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/app/src/main/java/com/dinuscxj/example/adapter/HeaderViewRecyclerAdapter.java
+++ b/app/src/main/java/com/dinuscxj/example/adapter/HeaderViewRecyclerAdapter.java
@@ -1,8 +1,8 @@
 package com.dinuscxj.example.adapter;
 
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.StaggeredGridLayoutManager;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.StaggeredGridLayoutManager;
 import android.view.View;
 import android.view.ViewGroup;
 

--- a/app/src/main/java/com/dinuscxj/example/adapter/RecyclerListAdapter.java
+++ b/app/src/main/java/com/dinuscxj/example/adapter/RecyclerListAdapter.java
@@ -1,7 +1,7 @@
 package com.dinuscxj.example.adapter;
 
-import android.support.annotation.NonNull;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.view.ViewGroup;
 

--- a/app/src/main/java/com/dinuscxj/example/demo/MaterialRefreshView.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/MaterialRefreshView.java
@@ -10,7 +10,7 @@ import android.graphics.RectF;
 import android.graphics.Shader;
 import android.graphics.drawable.ShapeDrawable;
 import android.graphics.drawable.shapes.OvalShape;
-import android.support.v4.view.ViewCompat;
+import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.LinearInterpolator;
@@ -95,7 +95,7 @@ public class MaterialRefreshView extends View implements IRefreshStatus {
         } else {
             OvalShape oval = new OvalShadow(mShadowRadius, diameter);
             circle = new ShapeDrawable(oval);
-            ViewCompat.setLayerType(this, ViewCompat.LAYER_TYPE_SOFTWARE, circle.getPaint());
+            ViewCompat.setLayerType(this, View.LAYER_TYPE_SOFTWARE, circle.getPaint());
             circle.getPaint().setShadowLayer(mShadowRadius, shadowXOffset, shadowYOffset,
                     KEY_SHADOW_COLOR);
             final int padding = mShadowRadius;

--- a/app/src/main/java/com/dinuscxj/example/demo/OpenProjectFloatFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/OpenProjectFloatFragment.java
@@ -4,10 +4,11 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/app/src/main/java/com/dinuscxj/example/demo/OpenProjectNormalFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/OpenProjectNormalFragment.java
@@ -5,10 +5,11 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
 import android.view.Menu;

--- a/app/src/main/java/com/dinuscxj/example/demo/OpenProjectPinnedFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/OpenProjectPinnedFragment.java
@@ -4,10 +4,11 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/app/src/main/java/com/dinuscxj/example/demo/OpenProjectRefreshActivity.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/OpenProjectRefreshActivity.java
@@ -1,7 +1,7 @@
 package com.dinuscxj.example.demo;
 
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 
 import com.dinuscxj.example.R;
 

--- a/app/src/main/java/com/dinuscxj/example/demo/OpenProjectTabPagerFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/OpenProjectTabPagerFragment.java
@@ -1,8 +1,8 @@
 package com.dinuscxj.example.demo;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
+import androidx.annotation.NonNull;
+import androidx.fragment.app.Fragment;
 
 import com.dinuscxj.example.R;
 

--- a/app/src/main/java/com/dinuscxj/example/demo/RecyclerFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/RecyclerFragment.java
@@ -1,11 +1,12 @@
 package com.dinuscxj.example.demo;
 
 import android.os.Bundle;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.v4.app.Fragment;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/com/dinuscxj/example/demo/RefreshViewEg.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/RefreshViewEg.java
@@ -7,7 +7,7 @@ import android.view.animation.Animation;
 import android.view.animation.DecelerateInterpolator;
 import android.view.animation.Interpolator;
 import android.view.animation.RotateAnimation;
-import android.widget.ImageView;
+import androidx.appcompat.widget.AppCompatImageView;
 
 import com.dinuscxj.example.R;
 import com.dinuscxj.refresh.IRefreshStatus;
@@ -15,7 +15,7 @@ import com.dinuscxj.refresh.IRefreshStatus;
 /**
  * the default implementation class of the interface IRefreshStatus, and the class should always be rewritten
  */
-public class RefreshViewEg extends android.support.v7.widget.AppCompatImageView implements IRefreshStatus {
+public class RefreshViewEg extends AppCompatImageView implements IRefreshStatus {
     private static final int ANIMATION_DURATION = 150;
     private static final Interpolator ANIMATION_INTERPOLATOR = new DecelerateInterpolator();
 

--- a/app/src/main/java/com/dinuscxj/example/demo/TabPagerFragment.java
+++ b/app/src/main/java/com/dinuscxj/example/demo/TabPagerFragment.java
@@ -4,19 +4,20 @@ import android.os.Bundle;
 import android.os.Parcel;
 import android.os.ParcelFormatException;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentStatePagerAdapter;
-import android.support.v4.view.ViewPager;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.Toolbar;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentStatePagerAdapter;
+import androidx.viewpager.widget.ViewPager;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.dinuscxj.example.R;
+import com.google.android.material.tabs.TabLayout;
 
 import java.util.ArrayList;
 

--- a/app/src/main/java/com/dinuscxj/example/tips/DefaultTipsHelper.java
+++ b/app/src/main/java/com/dinuscxj/example/tips/DefaultTipsHelper.java
@@ -1,7 +1,7 @@
 package com.dinuscxj.example.tips;
 
 import android.graphics.drawable.AnimationDrawable;
-import android.support.v7.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.ImageView;

--- a/app/src/main/res/layout/base_refresh_recycler_list_layout.xml
+++ b/app/src/main/res/layout/base_refresh_recycler_list_layout.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.v7.widget.RecyclerView
+    <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/base_tabpager_fragment.xml
+++ b/app/src/main/res/layout/base_tabpager_fragment.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:elevation="0dp"
         android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
 
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
@@ -19,17 +19,17 @@
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
             app:layout_scrollFlags="scroll|enterAlways" />
 
-        <android.support.design.widget.TabLayout
+        <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/simple_list_item.xml
+++ b/app/src/main/res/layout/simple_list_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v7.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginLeft="8dp"
@@ -43,4 +43,4 @@
             android:textColor="@android:color/white"
             android:textSize="18sp" />
     </LinearLayout>
-</android.support.v7.widget.CardView>
+</androidx.cardview.widget.CardView>

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,9 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.1'
@@ -13,6 +16,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        maven {
+            url 'https://maven.google.com/'
+        }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+android.enableJetifier=false
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/recyclerrefreshlayout/build.gradle
+++ b/recyclerrefreshlayout/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'androidx.appcompat:appcompat:1.0.0'
 }
 
 

--- a/recyclerrefreshlayout/build.gradle
+++ b/recyclerrefreshlayout/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 11
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/recyclerrefreshlayout/src/main/java/com/dinuscxj/refresh/RecyclerRefreshLayout.java
+++ b/recyclerrefreshlayout/src/main/java/com/dinuscxj/refresh/RecyclerRefreshLayout.java
@@ -1,16 +1,15 @@
 package com.dinuscxj.refresh;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.v4.view.MotionEventCompat;
-import android.support.v4.view.NestedScrollingChild;
-import android.support.v4.view.NestedScrollingChildHelper;
-import android.support.v4.view.NestedScrollingParent;
-import android.support.v4.view.NestedScrollingParentHelper;
-import android.support.v4.view.ViewCompat;
+import androidx.annotation.NonNull;
+import androidx.core.view.MotionEventCompat;
+import androidx.core.view.NestedScrollingChild;
+import androidx.core.view.NestedScrollingChildHelper;
+import androidx.core.view.NestedScrollingParent;
+import androidx.core.view.NestedScrollingParentHelper;
+import androidx.core.view.ViewCompat;
 import android.util.AttributeSet;
 import android.util.DisplayMetrics;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewConfiguration;
@@ -22,7 +21,7 @@ import android.view.animation.Transformation;
 import android.widget.AbsListView;
 
 /**
- * NOTE: the class based on the {@link android.support.v4.widget.SwipeRefreshLayout} source code
+ * NOTE: the class based on the {@link androidx.core.widget.SwipeRefreshLayout} source code
  * <p>
  * The RecyclerRefreshLayout should be used whenever the user can refresh the
  * contents of a view via a vertical swipe gesture. The activity that

--- a/recyclerrefreshlayout/src/main/java/com/dinuscxj/refresh/RefreshView.java
+++ b/recyclerrefreshlayout/src/main/java/com/dinuscxj/refresh/RefreshView.java
@@ -6,7 +6,6 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
-import android.support.v4.view.animation.FastOutSlowInInterpolator;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.animation.LinearInterpolator;


### PR DESCRIPTION
This PR does a _conservative_ migration from Support Library v25 to AndroidX.

The last version of the Android Support Library was v28. It has been deprecated for some time now, and superseded by AndroidX since it became stable in September 2018. Most open source projects have long migrated to AndroidX, but not `RecyclerRefreshLayout`. This PR changes that.

Migrating to AndroidX also removes the need for `RecyclerRefreshLayout` to be 'jetified', which is the compile-time migration of support-library-dependent libraries to equivalent AndroidX packages.

The migration is 'conservative' in the sense that it attempts to only migrate the dependencies and imports to AndroidX, without introducing any other project/code changes. I.e. the Android gradle build tools and gradle wrapper versions remain unchanged. However, some changes are unavoidable. The main one being:

- Support Library v26 raised the minSdkVersion for most libraries tot API 14. That's still the minimum supported Android version required for the AndroidX artifacts `RecyclerRefreshLayout` depends on.